### PR TITLE
Add ArrayBuffer to supported BufferLike types

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ hexdump(buffer: BufferLike, {
   - allow types:
     - `number[]`
     - `string` (convert to Buffer with utf8 encoding)
+    - `ArrayBuffer`
     - `Uint8Array`, `ClampledUint8Array`, `Int8Array`
     - `Uint16Array`, `Int16Array` (use endianness option)
     - `Uint32Array`, `Int32Array` (use endianness option)

--- a/src/modules/BufferLike.ts
+++ b/src/modules/BufferLike.ts
@@ -5,6 +5,7 @@ export type BufferLike =
   | Buffer
   | number[]
   | string
+  | ArrayBuffer
   | Uint8Array
   | Uint8ClampedArray
   | Int8Array
@@ -32,6 +33,7 @@ export const getBuffer = (
   }
 
   if (
+    value instanceof ArrayBuffer ||
     value instanceof Uint8Array ||
     value instanceof Uint8ClampedArray ||
     value instanceof Int8Array


### PR DESCRIPTION
A trivial change as `Buffer.from()` already supports `ArrayBuffer`, although in this case it shares the original data rather than copying it. That won't cause a problem with how it's used in `hexdump()`.